### PR TITLE
fix incorrect rounding for negative values

### DIFF
--- a/plstm_cell.py
+++ b/plstm_cell.py
@@ -35,7 +35,7 @@ class GradMod(torch.autograd.Function):
         with respect to the input.
         """
         x, y = ctx.saved_variables
-        return grad_output * 1, grad_output * torch.neg(torch.floor_divide(x, y))
+        return grad_output * 1, grad_output * torch.neg(torch.div(x, y, rounding_mode='floor'))
 
 class PLSTM(nn.Module):
     def __init__(self, input_sz, hidden_sz):


### PR DESCRIPTION
In PyTorch 1.12 and earlier, floor_divide rounds toward 0. This uses actual floor division to prevent such behaviour.